### PR TITLE
update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
   nextVersionCode:
     description: 'The next version code'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/index.js'


### PR DESCRIPTION
fix github warning https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/